### PR TITLE
upgrade to cypress v10 & fix windows issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.0.2 - 2022-11-25
+
+### Added
+
+-   CI and Release pipeline
+
+-   Compability with cypress below v10
+
+-   If Cypress v10 or higher specific file to run path specifications acording to official docs
+
+### Fixed
+
+-   Update dependencies vulnerabilities
+
+-   Find Config file method
+
+-   Build cypress executable script for Windows
+
 ## 1.0.2 - 2022-09-08
 
 ### Added

--- a/src/command.ts
+++ b/src/command.ts
@@ -64,7 +64,7 @@ export class CypressRunner {
     private buildCypressArgs(filePath: string): string[] {
         const args: string[] = [];
 
-        const cypressConfigPath = this.config.getCypressConfigPath(filePath);
+        const cypressConfigPath = this.config.getCypressConfigPath();
         if (cypressConfigPath) {
             args.push('--config-file');
             args.push(quote(cypressConfigPath));

--- a/src/command.ts
+++ b/src/command.ts
@@ -21,7 +21,19 @@ export class CypressRunner {
 
         await editor.document.save();
 
-        const filePath = workspace.asRelativePath(editor.document.fileName);
+        const cypressVersion = await this.config.getCypressVersion();
+
+        let filePath;
+
+        /**
+         * FIXME:
+         * Add configuration variable that allow user to select if cypress version is below 10
+         */
+        if (cypressVersion && parseInt(cypressVersion) < 10) {
+            filePath = editor.document.fileName;
+        } else {
+            filePath = workspace.asRelativePath(editor.document.fileName);
+        }
 
         const command = this.buildCypressCommand(filePath);
 
@@ -56,12 +68,12 @@ export class CypressRunner {
     /* Private methods */
 
     private buildCypressCommand(filePath: string): string {
-        const args = this.buildCypressArgs(filePath);
+        const args = this.buildCypressArgs();
 
         return `${this.config.cypressCommand} --spec ${quote(filePath)} ${args.join(' ')}`;
     }
 
-    private buildCypressArgs(filePath: string): string[] {
+    private buildCypressArgs(): string[] {
         const args: string[] = [];
 
         const cypressConfigPath = this.config.getCypressConfigPath();

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,4 @@
-import { commands, Range, Terminal, window } from 'vscode';
+import { commands, Range, Terminal, window, workspace } from 'vscode';
 import { state } from './codeLens/codeLensProvider';
 import { CypressRunnerConfig } from './config';
 import { quote } from './utils';
@@ -21,7 +21,7 @@ export class CypressRunner {
 
         await editor.document.save();
 
-        const filePath = editor.document.fileName;
+        const filePath = workspace.asRelativePath(editor.document.fileName);
 
         const command = this.buildCypressCommand(filePath);
 
@@ -56,29 +56,26 @@ export class CypressRunner {
     /* Private methods */
 
     private buildCypressCommand(filePath: string): string {
-         const args = this.buildCypressArgs(filePath);
-     
+        const args = this.buildCypressArgs(filePath);
+
         return `${this.config.cypressCommand} --spec ${quote(filePath)} ${args.join(' ')}`;
     }
 
     private buildCypressArgs(filePath: string): string[] {
         const args: string[] = [];
-        
+
         const cypressConfigPath = this.config.getCypressConfigPath(filePath);
         if (cypressConfigPath) {
-          args.push('--config-file');
-          args.push(quote(cypressConfigPath));
+            args.push('--config-file');
+            args.push(quote(cypressConfigPath));
         }
-    
-        
-        if (this.config.runOptions) {
-          this.config.runOptions.forEach((option) => args.push(option));
-        }
-        
-        return args;
-      }
-    
 
+        if (this.config.runOptions) {
+            this.config.runOptions.forEach((option) => args.push(option));
+        }
+
+        return args;
+    }
 
     private async goToCwd() {
         if (this.config.changeDirectoryToWorkspaceRoot) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ export class CypressRunnerConfig {
             return <string>cypressCommand;
         }
 
-        return `${quote(this.cypressBinPath)} run`;
+        return isWindows() ? `node ${quote(this.cypressBinPath)} run` : `${quote(this.cypressBinPath)} run`;
     }
 
     private findConfigPath(targetPath?: string): string {
@@ -75,17 +75,16 @@ export class CypressRunnerConfig {
     public get runOptions(): string[] | null {
         const runOptions = workspace.getConfiguration().get('cypressrunner.runOptions');
         if (runOptions) {
-          if (Array.isArray(runOptions)) {
-            return runOptions;
-          } else {
-            window.showWarningMessage(
-              'Please check your vscode settings. "cypressrunner.runOptions" must be an Array. '
-            );
-          }
+            if (Array.isArray(runOptions)) {
+                return runOptions;
+            } else {
+                window.showWarningMessage(
+                    'Please check your vscode settings. "cypressrunner.runOptions" must be an Array. ',
+                );
+            }
         }
         return null;
-      }
-    
+    }
 
     public get cwd(): string {
         return (

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,15 +8,13 @@ export class CypressRunnerConfig {
         return workspace.getConfiguration().get('cypressrunner.changeDirectoryToWorkspaceRoot');
     }
 
-    getCypressConfigPath(targetPath: string): string {
+    getCypressConfigPath(): string | null {
         // custom
         const configPath: string | undefined = workspace.getConfiguration().get('cypressrunner.configPath');
-        if (!configPath) {
-            return this.findConfigPath(targetPath);
+        if (configPath && configPath.length > 0) {
+            return normalizePath(path.join(this.currentWorkspaceFolderPath, configPath));
         }
-
-        // default
-        return normalizePath(path.join(this.currentWorkspaceFolderPath, configPath));
+        return null;
     }
 
     public get cypressCommand(): string {
@@ -29,6 +27,7 @@ export class CypressRunnerConfig {
         return isWindows() ? `node ${quote(this.cypressBinPath)} run` : `${quote(this.cypressBinPath)} run`;
     }
 
+    // FIXME: Unable to return default config path
     private findConfigPath(targetPath?: string): string {
         if (window.activeTextEditor !== undefined) {
             let currentFolderPath: string = targetPath || path.dirname(window.activeTextEditor.document.fileName);

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ export class CypressRunnerConfig {
             let currentFolderPath: string = targetPath || path.dirname(window.activeTextEditor.document.fileName);
             let currentFolderConfigPath: string;
             do {
-                for (const configFilename of ['cypress.json']) {
+                for (const configFilename of ['cypress.json', 'cypress.config.ts']) {
                     currentFolderConfigPath = path.join(currentFolderPath, configFilename);
 
                     if (fs.existsSync(currentFolderConfigPath)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,10 @@ export function normalizePath(path: string): string {
     return isWindows() ? path.replace(/\\/g, '/') : path;
 }
 
+export function convertPathToWindows(path: string) {
+    return isWindows() ? path.replace(/\//g, '\\') : path;
+}
+
 export function escapeRegExpForPath(s: string): string {
     return s.replace(/[*+?^${}<>()|[\]]/g, '\\$&'); // $& means the whole matched string
 }


### PR DESCRIPTION
As cypress from v10 to forward to run specific spec file, path to file needs to be relative and pointing to specs directory updates on the library are needed 

Also this PR fixes existing issues with plugin running on Windows OS 